### PR TITLE
Remove bucket from storage once the bucket is full

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -37,10 +37,12 @@ function normalizeType(params) {
     type.size = type.per_interval;
   }
 
-  type.ttl = (type.size * type.interval) / type.per_interval;
+  if (type.per_interval) {
+    type.ttl = (type.size * type.interval) / type.per_interval;
 
-  if (process.env.NODE_ENV !== 'test') {
-    type.ttl += GC_GRACE_PERIOD;
+    if (process.env.NODE_ENV !== 'test') {
+      type.ttl += GC_GRACE_PERIOD;
+    }
   }
 
   type.overrides = _.map(params.overrides || params.override || {}, (overrideDef, name) => {
@@ -142,6 +144,14 @@ class LimitDB {
     return result;
   }
 
+  _getFullBucket(typeParams) {
+    return {
+      lastDrip: Date.now(),
+      content: typeParams.size,
+      reset: this._getResetTimestamp({ content: typeParams.size }, typeParams.size)
+    };
+  }
+
   take(params, callback) {
     if (typeof params !== 'object') {
       params = {};
@@ -179,10 +189,7 @@ class LimitDB {
         bucket = JSON.parse(bucket);
       }
 
-      bucket = bucket ? this._drip(bucket, typeParams) : {
-        lastDrip: Date.now(),
-        content: typeParams.size
-      };
+      bucket = bucket ? this._drip(bucket, typeParams) : this._getFullBucket(typeParams);
 
       //this happen when we scale down a bucket
       //imagine the size was 10 and the current content is 9.
@@ -294,11 +301,19 @@ class LimitDB {
       };
 
       bucket.content = Math.min(typeParams.size, bucket.content + count);
-      return bucket;
+
+      // Storage optimization: if the bucket is full we can remove it from DB.
+      // this partially fixes an issue causing us to collect items in DB indefinitelly
+      // those items in general exceed the existing limit of 100 items
+      // we return when calling bucket status
+      return bucket.content === bucket.size ? null : bucket;
     }, { ttl: typeParams.ttl }, (err, bucket) => {
       if (err) {
         return callback(err);
       }
+
+      bucket = bucket || this._getFullBucket(typeParams);
+
       callback(null, {
         remaining:  Math.floor(bucket.content),
         reset:      bucket.reset,

--- a/lib/gms.js
+++ b/lib/gms.js
@@ -61,12 +61,21 @@ module.exports = function(db) {
 
       const last = queue[queue.length - 1];
 
-      this.put(key, finalResult, last.putParams, (err) => {
-        if (err) {
-          queue.forEach(queued => queued.callback(err));
-        }
-        intermediateResults.forEach((ir, index) => queue[index].callback(null, ir));
-      });
+      if (finalResult) {
+        this.put(key, finalResult, finalResult.params, (err) => {
+          if (err) {
+            return queue.forEach(queued => queued.callback(err));
+          }
+          intermediateResults.forEach((ir, index) => queue[index].callback(null, ir));
+        });
+      } else {
+        this.del(key, (err) => {
+          if (err) {
+            return queue.forEach(queued => queued.callback(err));
+          }
+          intermediateResults.forEach((ir, index) => queue[index].callback(null, ir));
+        })
+      }
     });
   };
 

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -91,6 +91,36 @@ describe('LimitDB', () => {
       });
     });
 
+    it('should return TRUE with right remaining and reset after filling up the bucket', (done) => {
+      var now = 1425920267;
+      db.take({
+        type: 'ip',
+        key:  '5.5.5.5'
+      }, function (err) {
+        if (err) return done(err);
+        db.put({
+          type: 'ip',
+          key:  '5.5.5.5',
+        }, (err) => {
+          if (err) return done(err);
+          MockDate.set(now * 1000);
+          db.take({
+            type: 'ip',
+            key:  '5.5.5.5'
+          }, function (err, result) {
+            if (err) return done(err);
+
+            assert.ok(result.conformant);
+            assert.equal(result.remaining, 9);
+            assert.equal(result.reset, now + 1);
+            assert.equal(result.limit, 10);
+
+            done();
+          });
+        });
+      });
+    });
+
     it('should return TRUE when traffic is conformant', (done) => {
       var now = 1425920267;
       MockDate.set(now * 1000);


### PR DESCRIPTION
This is an optimization that saves storage space and at
the same time helps us prevent reaching the limit of 100
items that is part of .status response in most of the cases.