### PR TITLE
fix inMemory parameter and remove memdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const limitdb = new Limitdb({
 Options available:
 
 - `path` (string): a path for the leveldb database.
-- `inMemory` (boolean): true to run with [memdown](https://github.com/Level/memdown). This is useful for tests.
+- `inMemory` (boolean): true to run with [memdown](https://github.com/Level/memdown).
 - `types` (object): setup your bucket types.
 
 The type defines the characteristics of a the bucket:

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,7 +5,7 @@ const ttl    = require('level-ttl');
 const spaces = require('level-spaces');
 const ms     = require('ms');
 const _      = require('lodash');
-const leveldown = require('leveldown');
+const leveldb = require('leveldown');
 const gms    = require('./gms');
 const LRU    = require('lru-cache');
 const EventEmitter = require('events').EventEmitter;
@@ -18,9 +18,17 @@ const INTERVAL_TO_MS = {
   'per_day':    ms('1d')
 };
 
+const drivers = {
+  'leveldb': leveldb
+};
+
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
 const GC_GRACE_PERIOD = ms('2m');
 
+const defaults = {
+  driver: 'leveldb',
+  inMemory: false
+};
 
 function normalizeType(params) {
   const type = _.pick(params, [
@@ -68,11 +76,11 @@ class LimitDB extends EventEmitter {
     super();
     params = params || {};
 
+    params = Object.assign({}, defaults, params);
+
     if (typeof params.path !== 'string' && !params.inMemory) {
       throw new Error('path is required');
     }
-
-    const dbPath = !params.inMemory ? params.path : undefined;
 
     const done = (err, db, types) => {
       if (err) {
@@ -83,47 +91,47 @@ class LimitDB extends EventEmitter {
       this.emit('ready');
     };
 
-    if (!dbPath) {
-      this._openDb(undefined, params, done);
+    const leveldbOnFs = params.driver === 'leveldb' && !params.inMemory;
+
+    if (leveldbOnFs) {
+      this._safeOpenDb(params, done);
     } else {
-      this._safeOpenDb(dbPath, params, done);
+      this._openDb(params, done);
     }
   }
 
-  _safeOpenDb(dbPath, params, done) {
-    dbChecker.check(dbPath, (err) => {
+  _safeOpenDb(params, done) {
+    dbChecker.check(params.path, (err) => {
       if (err) {
         this.emit('repairing');
-        return leveldown.repair(dbPath, (err) => {
+        return leveldb.repair(params.path, (err) => {
           if (err) {
             this.emit('error', err);
             return;
           }
-          this._openDb(dbPath, params, done);
+          this._openDb(params.path, params, done);
         });
       }
-      this._openDb(dbPath, params, done);
+      this._openDb(params.path, params, done);
     });
   }
 
-  _openDb(dbPath, params, callback) {
-    level(dbPath, {
-      db: params.inMemory ? require('memdown') : undefined,
+  _openDb(params, callback) {
+    const db = drivers[params.driver];
+    const memory = params.inMemory && params.driver === 'leveldb' || undefined;
+
+    level(params.path || '', {
+      db,
+      memory,
       valueEncoding: 'json'
     }, (err, db) => {
       if (err) {
         return callback(err);
       }
 
-      if (!params.inMemory) {
-        db = ttl(db, {
-          checkFrequency: process.env.NODE_ENV === 'test' ? 100 : ms('30s')
-        });
-      } else {
-        if (process.env.NODE_ENV !== 'test') {
-          console.warn('inMemory doesnt support GC yet');
-        }
-      }
+      db = ttl(db, {
+        checkFrequency: process.env.NODE_ENV === 'test' ? 100 : ms('30s')
+      });
 
       const types = _.reduce(params.types, (result, typeParams, name) => {
         const type = result[name] = normalizeType(typeParams);

--- a/package.json
+++ b/package.json
@@ -16,11 +16,10 @@
     "fast-clone": "^1.4.2",
     "level-spaces": "~1.1.1",
     "level-ttl": "limitd/level-ttl#limitd_changes",
-    "leveldown": "github:limitd/leveldown#options",
+    "leveldown": "github:limitd/leveldown#noprebuild_options",
     "levelup": "^1.3.5",
     "lodash": "^4.17.4",
     "lru-cache": "^4.0.2",
-    "memdown": "^1.2.4",
     "ms": "^0.7.3"
   },
   "devDependencies": {

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -97,8 +97,7 @@ describe('LimitDB', () => {
     });
 
 
-    //this doesn't work because inMemory doesn't support GC
-    it.skip('should add a ttl to unused buckets', function (done) {
+    it('should add a ttl to unused buckets', function (done) {
       const params = { type: 'ip', key: '211.45.66.1'};
       db.take(params, function (err) {
         if (err) return done(err);


### PR DESCRIPTION
We don't need memdown any more because our fork of leveldb currently supports the `memory` parameter. In fact it works better, because it works exactly as leveldb so Garbage Collection can be used now with `inMemory: true`.

Please notice that before this PR we where not using the fork properly because it was downloading prebuild binaries from the main repository, I've created another branch removing that:

https://github.com/Level/leveldown/commit/08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5