### PR TITLE
Support TTL

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -39,7 +39,8 @@ function normalizeType(params) {
     'per_interval',
     'interval',
     'size',
-    'unlimited'
+    'unlimited',
+    'ttl'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(ish => {
@@ -52,7 +53,7 @@ function normalizeType(params) {
     type.size = type.per_interval;
   }
 
-  if (type.per_interval) {
+  if (type.per_interval && !type.ttl) {
     type.ttl = (type.size * type.interval) / type.per_interval;
 
     if (process.env.NODE_ENV !== 'test') {

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -34,6 +34,10 @@ const types = {
         size: 10
       }
     }
+  },
+  ttl_test: {
+    size: 10,
+    ttl: 100
   }
 };
 
@@ -135,6 +139,19 @@ describeForEachConfig((getConfig) => {
             done();
           });
         }, 3000);
+      });
+    });
+
+    it('should support specifying a ttl in the bucket configuration', function (done) {
+      const params = { type: 'ttl_test', key: '211.45.66.1'};
+      db.take(params, function (err) {
+        if (err) return done(err);
+        setTimeout(function () {
+          db._types[params.type].db.get(params.key, function (err, result) {
+            assert.isUndefined(result);
+            done();
+          });
+        }, 300);
       });
     });
 


### PR DESCRIPTION
Supports specifying ttl into the bucket configuration. So we can avoid
limitless disk consumption in the case of fixed (buckets without refill)
buckets